### PR TITLE
Allow users to edit products

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -30,6 +30,29 @@ class ProductsController < ApplicationController
     redirect_to products_path
   end
 
+  def edit
+    product = Product.find(params[:id])
+
+    if product
+      render locals: { product: product }
+    else
+      flash[:error] = "Product not found"
+      redirect_to products_path
+    end
+  end
+
+  def update
+    product = Product.find(params[:id])
+
+    if product.update(product_params)
+      flash[:success] = "Product updated"
+      redirect_to products_path
+    else
+      flash[:error] = product.errors.full_messages
+      redirect_to products_path
+    end
+  end
+
   private
 
   def product_params

--- a/app/views/products/_product.html.erb
+++ b/app/views/products/_product.html.erb
@@ -4,5 +4,6 @@
   <%= product.version %>
   <%= product.date %>
   <%= product.value %>
+  <%= link_to "Edit", edit_product_url(product) %>
   <%= button_to "Delete", product_url(product), method: :delete, confirm: "Are you sure?" %>
 </li>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,0 +1,3 @@
+Edit Product Form
+
+<%= render "form", product: product %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   root "products#index"
 
-  resources :products, only: %i[index new create destroy]
+  resources :products, only: %i[index new create destroy edit update]
+  resources :imports, only: %i[create]
 end

--- a/spec/features/user_edits_a_product_spec.rb
+++ b/spec/features/user_edits_a_product_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe "user edits a product spec" do
+  scenario "by clicking the edit link on the products index" do
+    product = create(:product)
+    new_name = Faker::App.name
+    new_version = Faker::App.version
+    new_value = Faker::Number.number(5).to_i
+    new_author = Faker::Name.name
+
+    visit products_path
+
+    click_on "Edit"
+    expect(page).to have_content("Edit Product")
+
+    fill_in "Name", with: new_name
+    fill_in "Version", with: new_version
+    fill_in "Value", with: new_value
+    fill_in "Author", with: new_author
+
+    click_on "Update Product"
+
+    product = Product.last
+    expect(product.name).to eq(new_name)
+    expect(product.version).to eq(new_version)
+    expect(product.value).to eq(new_value)
+    expect(product.author).to eq(new_author)
+
+    expect(page).to have_content("Products Index")
+  end
+end

--- a/spec/views/products/_product.html.erb_spec.rb
+++ b/spec/views/products/_product.html.erb_spec.rb
@@ -13,11 +13,12 @@ RSpec.describe "products/_product.html.erb" do
     expect(rendered).to have_text(product.value)
   end
 
-  it "renders a delete button" do
+  it "renders a delete button and an edit link" do
     product = build_stubbed(:product)
 
     render template: "products/_product.html.erb", locals: { product: product }
 
-    expect(rendered).to have_link("Delete")
+    expect(rendered).to have_link("Edit")
+    expect(rendered).to have_button("Delete")
   end
 end

--- a/spec/views/products/edit.html.erb_spec.rb
+++ b/spec/views/products/edit.html.erb_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+
+RSpec.describe "products/edit.html.erb" do
+  it "renders a form for editing a product" do
+    product = build_stubbed(:product)
+
+    render template: "products/edit.html.erb", locals: { product: product }
+
+    expect(rendered).to have_content("Edit Product Form")
+  end
+end


### PR DESCRIPTION
Why:
We would like for users to be able to update products.

This commit:
Adds an edit product page and an update action to update products.