### PR TITLE
Allow users to upload files of products

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,0 +1,6 @@
+class ImportsController < ApplicationController
+  def create
+    Product.import(params[:file].path)
+    redirect_to products_path, notice: "Succesfully imported"
+  end
+end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,14 @@
+require "csv"
+
 class Product < ApplicationRecord
   validates :name, presence: true
+
+  def self.import(file_path)
+    CSV.foreach(file_path, headers: true) do |row|
+      data = row.to_h
+      data["active"] = data["active"] == "true"
+      product = new(data)
+      product.save
+    end
+  end
 end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,3 +7,9 @@ Products Index
 </ul>
 
 <%= link_to "Create a New Product", new_product_path %>
+
+<%= form_tag imports_path, multipart: true do %>
+  <label for="file">upload csv</label>
+  <%= file_field_tag "file" %>
+  <%= submit_tag "Upload File" %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   root "products#index"
 
   resources :products
+  resources :imports, only: %i[create]
 end

--- a/spec/features/user_uploads_a_csv_of_product_data_spec.rb
+++ b/spec/features/user_uploads_a_csv_of_product_data_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe "User uploads a file of produce data" do
+  scenario "by visiting the root page and clicking 'upload file'" do
+    visit root_path
+
+    attach_file("file", Rails.root.join("spec/fixtures/products.csv"))
+    click_on "Upload File"
+
+    expect(Product.count).to eq 3
+  end
+end

--- a/spec/fixtures/products.csv
+++ b/spec/fixtures/products.csv
@@ -1,0 +1,4 @@
+name,author,version,release_date,value,active
+name_a,author_a,1.10.3,20190101,100,true
+name_b,author_b,2.9,20190201,201,false
+name_c,author_c,0.53,20190302,3000,true

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -4,4 +4,30 @@ RSpec.describe Product, type: :model do
   describe "Validations" do
     it { should validate_presence_of(:name) }
   end
+
+  describe ".import" do
+    context "the file is a csv" do
+      it "saves every row in the file as new product" do
+        require "csv"
+        file =
+          CSV.generate do |csv|
+            csv << %w[name author release_date version value active]
+            csv << %w[name_a author_a 20190101 1.0 1 true]
+            csv << %w[name_b author_b 20190201 1.1 2 false]
+            csv << %w[name_c author_c 20190301 1.2 3 true]
+          end
+        filename = "test.csv"
+        allow(File).to receive(:open).with(
+                   filename,
+                   "r",
+                   { headers: true, universal_newline: false },
+                 )
+                   .and_return(file)
+
+        Product.import(filename)
+
+        expect(Product.count).to eq 3
+      end
+    end
+  end
 end


### PR DESCRIPTION
Why:
We would like for users to be able to upload a csv of product data from
the products index.

This commit:
Introduces an upload csv button to the products page, a new imports
controller, and a class method on Product to handle the import logic. A
sample fixture was added for a feature test.