### PR TITLE
Introduce product data importer

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,6 +1,7 @@
 class ImportsController < ApplicationController
   def create
-    Product.import(params[:file].path)
+    importer = ProductDataImporter.new(params[:file].path)
+    importer.import
     redirect_to products_path, notice: "Succesfully imported"
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,13 +2,4 @@ require "csv"
 
 class Product < ApplicationRecord
   validates :name, presence: true
-
-  def self.import(file_path)
-    CSV.foreach(file_path, headers: true) do |row|
-      data = row.to_h
-      data["active"] = data["active"] == "true"
-      product = new(data)
-      product.save
-    end
-  end
 end

--- a/app/models/product_data_importer.rb
+++ b/app/models/product_data_importer.rb
@@ -1,0 +1,15 @@
+class ProductDataImporter
+  attr_reader :filepath
+
+  def initialize(filepath)
+    @filepath = filepath
+  end
+
+  def import
+    CSV.foreach(filepath, headers: true) do |row|
+      data = row.to_h
+      data["active"] = data["active"] == "true"
+      Product.create(data)
+    end
+  end
+end

--- a/spec/models/product_data_importer_spec.rb
+++ b/spec/models/product_data_importer_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ProductDataImporter, type: :model do
+  describe "#import" do
+    context "the file is a csv" do
+      it "saves every row in the file as new product" do
+        require "csv"
+        filepath = stub_csv
+        importer = ProductDataImporter.new(filepath)
+
+        importer.import
+
+        expect(Product.count).to eq 3
+      end
+    end
+  end
+
+  def stub_csv(filename = "filename.csv")
+    file =
+      Tempfile.new(filename).tap do |f|
+        f.puts "name,author,release_date,version,value,active"
+        f.puts "name_a,author_a,20190101,1.0,1,true"
+        f.puts "name_b,author_b,20190201,1.1,2,false"
+        f.puts "name_c,author_c,20190301,1.2,3,true"
+        f.close
+      end
+    file.path
+  end
+end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -4,29 +4,4 @@ RSpec.describe Product, type: :model do
   describe "Validations" do
     it { should validate_presence_of(:name) }
   end
-
-  describe ".import" do
-    context "the file is a csv" do
-      it "saves every row in the file as new product" do
-        require "csv"
-        filepath = stub_csv
-
-        Product.import(filepath)
-
-        expect(Product.count).to eq 3
-      end
-    end
-  end
-
-  def stub_csv(filename = "filename.csv")
-    file =
-      Tempfile.new(filename).tap do |f|
-        f.puts "name,author,release_date,version,value,active"
-        f.puts "name_a,author_a,20190101,1.0,1,true"
-        f.puts "name_b,author_b,20190201,1.1,2,false"
-        f.puts "name_c,author_c,20190301,1.2,3,true"
-        f.close
-      end
-    file.path
-  end
 end


### PR DESCRIPTION
Why:
We would like to have a dedicated service object to handle the logic of
importing csv files for product data.

This commit:
Introduces a ProductDataImporter model and moves the import
functionality from Product.import to
ProductDataImporter#import