### PR TITLE
Introduce product data importer

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,6 +1,7 @@
 class ImportsController < ApplicationController
   def create
-    importer = ProductDataImporter.new(params[:file].path)
+    formatter = ProductDataFormatter.new
+    importer = ProductDataImporter.new(params[:file].path, formatter)
     importer.import
     redirect_to products_path, notice: "Succesfully imported"
   end

--- a/app/models/product_data_formatter.rb
+++ b/app/models/product_data_formatter.rb
@@ -1,0 +1,9 @@
+class ProductDataFormatter
+  def build(csv_row)
+    data = csv_row.to_h.symbolize_keys
+    data[:active] = data[:active] == "true"
+    data[:release_date] = Time.zone.parse(data[:release_date])
+    data[:value] = data[:value].to_i
+    data
+  end
+end

--- a/app/models/product_data_importer.rb
+++ b/app/models/product_data_importer.rb
@@ -1,15 +1,15 @@
 class ProductDataImporter
-  attr_reader :filepath
+  attr_reader :filepath, :formatter
 
-  def initialize(filepath)
+  def initialize(filepath, formatter)
     @filepath = filepath
+    @formatter = formatter
   end
 
   def import
     CSV.foreach(filepath, headers: true) do |row|
-      data = row.to_h
-      data["active"] = data["active"] == "true"
-      Product.create(data)
+      formatted_data = formatter.build(row)
+      Product.create(formatted_data)
     end
   end
 end

--- a/app/workers/product_import_worker.rb
+++ b/app/workers/product_import_worker.rb
@@ -2,6 +2,7 @@ class ProductImportWorker
   include Sidekiq::Worker
 
   def perform(file_path)
-    Product.import(file_path)
+    formatter = ProductDataFormatter.new
+    Product.import(file_path, formatter)
   end
 end

--- a/spec/models/product_data_formatter_spec.rb
+++ b/spec/models/product_data_formatter_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe ProductDataFormatter, type: :model do
+  describe "#build" do
+    it "builds a data hash from a csv_row for the product" do
+      headers = %w[name author version release_date value active]
+      fields = %w[name_a author_a 1.10.3 20190101 100 true]
+      csv_row = CSV::Row.new(headers, fields)
+      formatter = ProductDataFormatter.new
+
+      result = formatter.build(csv_row)
+
+      expect(result).to eq(
+                  {
+                    name: "name_a",
+                    author: "author_a",
+                    version: "1.10.3",
+                    release_date: Time.zone.parse("20190101"),
+                    value: 100,
+                    active: true,
+                  },
+                )
+    end
+  end
+end

--- a/spec/models/product_data_importer_spec.rb
+++ b/spec/models/product_data_importer_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe ProductDataImporter, type: :model do
       it "saves every row in the file as new product" do
         require "csv"
         filepath = stub_csv
-        importer = ProductDataImporter.new(filepath)
+        formatter = ProductDataFormatter.new
+        importer = ProductDataImporter.new(filepath, formatter)
 
         importer.import
 


### PR DESCRIPTION
Why:
We would like to be about to format incoming file rows before
creating Product records

This commit:
introduces a formatter class that can build up a formatted hash of
product attributes from a given csv_row.