### PR TITLE
Refactor importer and raise if unknown file type

### DIFF
--- a/app/models/csv_importer.rb
+++ b/app/models/csv_importer.rb
@@ -1,0 +1,17 @@
+require "csv"
+
+class CsvImporter
+  attr_reader :filepath, :formatter
+
+  def initialize(filepath, formatter)
+    @filepath = filepath
+    @formatter = formatter
+  end
+
+  def import
+    CSV.foreach(filepath, headers: true) do |row|
+      formatted_data = formatter.build_csv(row)
+      Product.create(formatted_data)
+    end
+  end
+end

--- a/app/models/product_data_importer.rb
+++ b/app/models/product_data_importer.rb
@@ -1,5 +1,3 @@
-require "csv"
-
 class ProductDataImporter
   attr_reader :filepath, :formatter
 
@@ -11,30 +9,11 @@ class ProductDataImporter
   def import
     case File.extname(filepath)
     when ".csv"
-      import_csv
+      CsvImporter.new(filepath, formatter).import
     when ".xlsx"
-      import_xlsx
-    end
-  end
-
-  private
-
-  def import_csv
-    CSV.foreach(filepath, headers: true) do |row|
-      formatted_data = formatter.build_csv(row)
-      Product.create(formatted_data)
-    end
-  end
-
-  def import_xlsx
-    workbook = RubyXL::Parser.parse(filepath)
-    worksheet = workbook.worksheets.first
-    worksheet.each_with_index do |row, idx|
-      if idx == 0
-        next
-      end
-      formatted_data = formatter.build_xlsx(row)
-      Product.create(formatted_data)
+      XlsxImporter.new(filepath, formatter).import
+    else
+      raise "Unknown file type"
     end
   end
 end

--- a/app/models/xlsx_importer.rb
+++ b/app/models/xlsx_importer.rb
@@ -1,0 +1,20 @@
+class XlsxImporter
+  attr_reader :filepath, :formatter
+
+  def initialize(filepath, formatter)
+    @filepath = filepath
+    @formatter = formatter
+  end
+
+  def import
+    workbook = RubyXL::Parser.parse(filepath)
+    worksheet = workbook.worksheets.first
+    worksheet.each_with_index do |row, idx|
+      if idx == 0
+        next
+      end
+      formatted_data = formatter.build_xlsx(row)
+      Product.create(formatted_data)
+    end
+  end
+end

--- a/spec/models/csv_importer_spec.rb
+++ b/spec/models/csv_importer_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe CsvImporter, type: :model do
+  describe "#import" do
+    it "saves every row in the file as new product" do
+      filename = "products.csv"
+      stub_csv(filename)
+      formatter = ProductDataFormatter.new
+      importer = CsvImporter.new(filename, formatter)
+
+      importer.import
+
+      expect(Product.count).to eq 3
+    end
+  end
+
+  def stub_csv(filename = "filename.csv")
+    file =
+      CSV.generate do |csv|
+        csv << %w[name author release_date version value active]
+        csv << %w[name_a author_a 20190101 1.0 1 true]
+        csv << %w[name_b author_b 20190201 1.1 2 false]
+        csv << %w[name_c author_c 20190301 1.2 3 true]
+      end
+    allow(File).to receive(:open).with(
+               filename,
+               "r",
+               { headers: true, universal_newline: false },
+             )
+               .and_return(file)
+  end
+end

--- a/spec/models/product_data_importer_spec.rb
+++ b/spec/models/product_data_importer_spec.rb
@@ -3,70 +3,45 @@ require "rails_helper"
 RSpec.describe ProductDataImporter, type: :model do
   describe "#import" do
     context "the file is a csv" do
-      it "saves every row in the file as new product" do
+      it "imports the file using a CsvImporter" do
         filename = "products.csv"
-        stub_csv(filename)
         formatter = ProductDataFormatter.new
         importer = ProductDataImporter.new(filename, formatter)
+        csv_importer_double = double("CsvImporter")
+        allow(csv_importer_double).to receive(:import)
+        allow(CsvImporter).to receive(:new).with(filename, formatter)
+                   .and_return(csv_importer_double)
 
         importer.import
 
-        expect(Product.count).to eq 3
+        expect(CsvImporter).to have_received(:new).with(filename, formatter)
       end
     end
 
     context "the file is a xlsx" do
       it "saves every row in the file as new product" do
         filename = "products.xlsx"
-        stub_xlsx(filename)
-
         formatter = ProductDataFormatter.new
         importer = ProductDataImporter.new(filename, formatter)
+        xlsx_importer_double = double("XlsxImporter")
+        allow(xlsx_importer_double).to receive(:import)
+        allow(XlsxImporter).to receive(:new).with(filename, formatter)
+                   .and_return(xlsx_importer_double)
 
         importer.import
 
-        expect(Product.count).to eq 3
+        expect(XlsxImporter).to have_received(:new).with(filename, formatter)
       end
     end
-  end
 
-  def stub_csv(filename = "filename.csv")
-    file =
-      CSV.generate do |csv|
-        csv << %w[name author release_date version value active]
-        csv << %w[name_a author_a 20190101 1.0 1 true]
-        csv << %w[name_b author_b 20190201 1.1 2 false]
-        csv << %w[name_c author_c 20190301 1.2 3 true]
+    context "the file is an unknown format" do
+      it "raises" do
+        filename = "products.unknown"
+        formatter = ProductDataFormatter.new
+        importer = ProductDataImporter.new(filename, formatter)
+
+        expect { importer.import }.to raise_error("Unknown file type")
       end
-    allow(File).to receive(:open).with(
-               filename,
-               "r",
-               { headers: true, universal_newline: false },
-             )
-               .and_return(file)
-  end
-
-  def stub_xlsx(filename = "filename.xlsx")
-    workbook = RubyXL::Workbook.new
-    workbook.add_worksheet("Sheet 1")
-    worksheet = workbook.worksheets.first
-    worksheet.add_cell(0, 0, "name")
-    worksheet.add_cell(0, 1, "author")
-    worksheet.add_cell(0, 2, "release_date")
-    worksheet.add_cell(0, 3, "version")
-    worksheet.add_cell(0, 4, "value")
-    worksheet.add_cell(0, 5, "active")
-
-    build_xlsx_row(worksheet, 1, %w[name_a author_a 20190101 1.0.1 true])
-    build_xlsx_row(worksheet, 2, %w[name_b author_b 20190201 1.1.1 true])
-    build_xlsx_row(worksheet, 3, %w[name_c author_c 20190301 1.2.1 true])
-
-    allow(RubyXL::Parser).to receive(:parse).with(filename).and_return(workbook)
-  end
-
-  def build_xlsx_row(worksheet, row_idx, row_data)
-    row_data.each_with_index do |value, col_idx|
-      worksheet.add_cell(row_idx, col_idx, value)
     end
   end
 end

--- a/spec/models/xlsx_importer_spec.rb
+++ b/spec/models/xlsx_importer_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe XlsxImporter, type: :model do
+  describe "#import" do
+    it "saves every row in the file as new product" do
+      filename = "products.xlsx"
+      stub_xlsx(filename)
+
+      formatter = ProductDataFormatter.new
+      importer = XlsxImporter.new(filename, formatter)
+
+      importer.import
+
+      expect(Product.count).to eq 3
+    end
+  end
+
+  def stub_xlsx(filename = "filename.xlsx")
+    workbook = RubyXL::Workbook.new
+    workbook.add_worksheet("Sheet 1")
+    worksheet = workbook.worksheets.first
+    worksheet.add_cell(0, 0, "name")
+    worksheet.add_cell(0, 1, "author")
+    worksheet.add_cell(0, 2, "release_date")
+    worksheet.add_cell(0, 3, "version")
+    worksheet.add_cell(0, 4, "value")
+    worksheet.add_cell(0, 5, "active")
+
+    build_xlsx_row(worksheet, 1, %w[name_a author_a 20190101 1.0.1 true])
+    build_xlsx_row(worksheet, 2, %w[name_b author_b 20190201 1.1.1 true])
+    build_xlsx_row(worksheet, 3, %w[name_c author_c 20190301 1.2.1 true])
+
+    allow(RubyXL::Parser).to receive(:parse).with(filename).and_return(workbook)
+  end
+
+  def build_xlsx_row(worksheet, row_idx, row_data)
+    row_data.each_with_index do |value, col_idx|
+      worksheet.add_cell(row_idx, col_idx, value)
+    end
+  end
+end


### PR DESCRIPTION
Why:
We would like to introduce dedicated service objects for importing
various file types. We would also like to raise if the importer is
provided a file type that is not know to the program

This commit:
factors out a new csv_importer and xlsx_importer from the
product_data_importer.