### PR TITLE
Strip $ from value attribute in formatter

### DIFF
--- a/app/models/product_data_formatter.rb
+++ b/app/models/product_data_formatter.rb
@@ -2,9 +2,11 @@ class ProductDataFormatter
   def format(data)
     data[:active] = data[:active] == "true"
     data[:release_date] = parse_release_date(data[:release_date])
-    data[:value] = data[:value].to_i
+    data[:value] = parse_value(data[:value])
     data
   end
+
+  private
 
   def parse_release_date(input)
     if input.is_a?(Float)
@@ -13,5 +15,9 @@ class ProductDataFormatter
       time = input
     end
     Time.zone.parse(time)
+  end
+
+  def parse_value(input)
+    input.to_s.gsub(/^\$/, "").to_i
   end
 end

--- a/spec/models/product_data_formatter_spec.rb
+++ b/spec/models/product_data_formatter_spec.rb
@@ -27,5 +27,32 @@ RSpec.describe ProductDataFormatter, type: :model do
                   },
                 )
     end
+
+    context "when the value has a dollar sign" do
+      it "strips the dollar sign" do
+        formatter = ProductDataFormatter.new
+        data = {
+          name: "name",
+          author: "author",
+          version: "0.0.0",
+          release_date: "20190101",
+          value: "$1230",
+          active: "true",
+        }
+
+        result = formatter.format(data)
+
+        expect(result).to eq(
+                    {
+                      name: "name",
+                      author: "author",
+                      version: "0.0.0",
+                      release_date: Time.zone.parse("20190101"),
+                      value: 1230,
+                      active: true,
+                    },
+                  )
+      end
+    end
   end
 end


### PR DESCRIPTION
Why:
We would like for users to be able to upload product data with or
without a leading '$' character.

This commit:
updates the formatter service object to handle the multiple formats for
the value attribute.