### PR TITLE
Introduce financial data importer module

### DIFF
--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -1,6 +1,6 @@
 class ImportsController < ApplicationController
   def create
-    Product.import(params[:file].path)
+    ProductsImporter.import(params[:file].path)
     redirect_to products_path, notice: "Succesfully imported"
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,13 +2,4 @@ require "csv"
 
 class Product < ApplicationRecord
   validates :name, presence: true
-
-  def self.import(file_path)
-    CSV.foreach(file_path, headers: true) do |row|
-      data = row.to_h
-      data["active"] = data["active"] == "true"
-      product = new(data)
-      product.save
-    end
-  end
 end

--- a/app/services/product_data_importer.rb
+++ b/app/services/product_data_importer.rb
@@ -1,0 +1,15 @@
+require "csv"
+
+class ProductDataImporter
+  def self.import(filepath)
+    new.import(filepath)
+  end
+
+  def import(filepath)
+    CSV.foreach(filepath, headers: true) do |row|
+      data = row.to_h
+      data["active"] = data["active"] == "true"
+      Product.create(data)
+    end
+  end
+end

--- a/app/workers/product_import_worker.rb
+++ b/app/workers/product_import_worker.rb
@@ -2,6 +2,6 @@ class ProductImportWorker
   include Sidekiq::Worker
 
   def perform(file_path)
-    Product.import(file_path)
+    ProductDataImporter.import(file_path)
   end
 end

--- a/spec/models/product_spec.rb
+++ b/spec/models/product_spec.rb
@@ -4,29 +4,4 @@ RSpec.describe Product, type: :model do
   describe "Validations" do
     it { should validate_presence_of(:name) }
   end
-
-  describe ".import" do
-    context "the file is a csv" do
-      it "saves every row in the file as new product" do
-        require "csv"
-        filepath = stub_csv
-
-        Product.import(filepath)
-
-        expect(Product.count).to eq 3
-      end
-    end
-  end
-
-  def stub_csv(filename = "filename.csv")
-    file =
-      Tempfile.new(filename).tap do |f|
-        f.puts "name,author,release_date,version,value,active"
-        f.puts "name_a,author_a,20190101,1.0,1,true"
-        f.puts "name_b,author_b,20190201,1.1,2,false"
-        f.puts "name_c,author_c,20190301,1.2,3,true"
-        f.close
-      end
-    file.path
-  end
 end

--- a/spec/services/products_importer_spec.rb
+++ b/spec/services/products_importer_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe FinancialDataImporter do
+  describe ".import" do
+    it "takes a file and creates product data from the data" do
+      filename = Rails.root.join("spec/fixtures/products.csv")
+      importer = ProductDataImporter.new
+
+      importer.import(filename)
+
+      expect(Product.count).to eq 3
+      last_product = Product.last
+      expect_product_to_match(
+        last_product,
+        "name_c",
+        "author_c",
+        "0.53",
+        Time.zone.parse("20190302"),
+        3000,
+        true,
+      )
+    end
+  end
+
+  def expect_datum_to_match(
+    product, name, author, release_date, value, version, active
+  )
+    expect(product.name).to eq(name)
+    expect(product.author).to eq(author)
+    expect(product.release_date).to eq(release_date)
+    expect(product.value).to eq(value)
+    expect(product.version).to eq(version)
+    expect(product.active).to eq(active)
+  end
+end


### PR DESCRIPTION
Why:
We would like to have an importer to contain the logic for importing
financial data.

This commit:
moves the import functionality from the financial datum model to a new
financial data importer class.