### PR TITLE
Strip $ from value attribute in import data

### DIFF
--- a/app/services/product_data_importer.rb
+++ b/app/services/product_data_importer.rb
@@ -41,9 +41,10 @@ class ProductDataImporter
   end
 
   def process_data(data)
-    parse_active(data).then { |data| parse_release_date(data) }.then do |data|
-      Product.create(data)
-    end
+    parse_active(data).
+      then { |data| parse_release_date(data) }.
+      then { |data| parse_value(data) }.
+      then { |data| Product.create(data) }
   end
 
   def parse_active(data)
@@ -53,6 +54,12 @@ class ProductDataImporter
 
   def parse_release_date(data)
     data[:release_date] = Time.zone.parse(data[:release_date].to_i.to_s)
+    data
+  end
+
+  def parse_value(data)
+    value = data[:value].to_s
+    data[:value] = value.gsub(/^\$/, "").to_i
     data
   end
 end

--- a/spec/fixtures/products.csv
+++ b/spec/fixtures/products.csv
@@ -1,4 +1,4 @@
 name,author,version,release_date,value,active
 name_a,author_a,1.10.3,20190101,100,true
 name_b,author_b,2.9,20190201,201,false
-name_c,author_c,0.53,20190302,3000,true
+name_c,author_c,0.53,20190302,$3000,true


### PR DESCRIPTION
Why:
We would like for users to be able to upload product data with or
without a leading '$' character.

this commit:
add parse_value step to process_data function in the importer.